### PR TITLE
Add support for Docker volume fs type as xfs

### DIFF
--- a/attachments/create_and_attach_volume.bash
+++ b/attachments/create_and_attach_volume.bash
@@ -63,12 +63,10 @@ esac
 [[ "$cloud_type" == *"azure"* ]] && DOCKER_DIR_BLOCK_DEVICE='01'
 
 echo 'Attaching the volume...'
-cmd="sudo /usr/local/bin/rsc --rl10 cm15 create --dump=debug $cloud_href/volume_attachments \
-  volume_attachment[device]=$DOCKER_DIR_BLOCK_DEVICE \
-  volume_attachment[instance_href]=$instance_href \
-  volume_attachment[volume_href]=$volume_href"
-echo "> $cmd"
-api_result=$(eval "$cmd" 2>&1 || true)
+api_result=$(sudo /usr/local/bin/rsc --rl10 cm15 create --dump=debug "$cloud_href/volume_attachments" \
+  volume_attachment[device]="$DOCKER_DIR_BLOCK_DEVICE" \
+  volume_attachment[instance_href]="$instance_href" \
+  volume_attachment[volume_href]="$volume_href" 2>&1)
 
 case "$api_result" in
   *"201 Created"*)

--- a/initialise_and_mount_docker_dir_volume.bash
+++ b/initialise_and_mount_docker_dir_volume.bash
@@ -114,8 +114,11 @@ btrfs)
 xfs)
   mkfs_cmd='mkfs.xfs -f -n ftype=1'
   ;;
-*)
+ext4)
   mkfs_cmd='mkfs.ext4'
+  ;;
+*)
+  mkfs_cmd="mkfs.$DOCKER_DIR_VOLUME_FSTYPE"
   ;;
 esac
 sudo $mkfs_cmd "$DOCKER_DIR_BLOCK_DEVICE"

--- a/initialise_and_mount_docker_dir_volume.bash
+++ b/initialise_and_mount_docker_dir_volume.bash
@@ -107,11 +107,17 @@ sudo chmod +rx /var/lib/docker
 echo 'Initialising volume...'
 sudo wipefs "$DOCKER_DIR_BLOCK_DEVICE"
 sleep 1
-if [ "$DOCKER_DIR_VOLUME_FSTYPE" = 'btrfs' ]; then
+case $DOCKER_DIR_VOLUME_FSTYPE in
+btrfs)
   mkfs_cmd='mkfs.btrfs -f'
-else
+  ;;
+xfs)
+  mkfs_cmd='mkfs.xfs -f -n ftype=1'
+  ;;
+*)
   mkfs_cmd='mkfs.ext4'
-fi
+  ;;
+esac
 sudo $mkfs_cmd "$DOCKER_DIR_BLOCK_DEVICE"
 
 # add volume to fstab


### PR DESCRIPTION
xfs+overlayfs will be piloted because Linux kernel 3.10 has a bug (1397330, RH internal buglizza) that unzipping a large file insider Docker container which runs on btrfs will result in VM reboot.

ext4+overlayfs was discussed as well but RH only official support xfs+overlayfs according to https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/7.2_Release_Notes/technology-preview-file_systems.html