### PR TITLE
Rancher deregister fails with error message - "conflict".

### DIFF
--- a/attachments/deactivate_and_delete_host.py
+++ b/attachments/deactivate_and_delete_host.py
@@ -58,18 +58,21 @@ print(client.by_id_host(host_id).actions)
 
 timeout = time.time() + 60*5   # 5 minutes from now
 while client.by_id_host(host_id).state != "purged":
-    if 'deactivate' in client.by_id_host(host_id).actions:
-        print('Deactivating host...')
-        client.by_id_host(host_id).deactivate()
-    elif 'remove' in client.by_id_host(host_id).actions:
-        print('Removing host...')
-        client.by_id_host(host_id).remove()
-    elif 'purge' in client.by_id_host(host_id).actions:
-        print('Purging host....')
-        client.by_id_host(host_id).purge()
+    try:
+        if 'deactivate' in client.by_id_host(host_id).actions:
+            print('Deactivating host...')
+            client.by_id_host(host_id).deactivate()
+        elif 'remove' in client.by_id_host(host_id).actions:
+            print('Removing host...')
+            client.by_id_host(host_id).remove()
+        elif 'purge' in client.by_id_host(host_id).actions:
+            print('Purging host....')
+            client.by_id_host(host_id).purge()
+
+    except Exception:
+        print('Failed to perform action. Retrying again')
 
     time.sleep(3)
-
     print('Current host state is: %s' % client.by_id_host(host_id).state)
 
     if time.time() > timeout:


### PR DESCRIPTION
Due to https://github.com/rancher/rancher/issues/5426 sometimes deregister fails. Fixing this by catching the exception and retrying again.